### PR TITLE
Add Granta MI BoM Analytics to landing page

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -570,7 +570,7 @@ Here's a brief example of how this package works:
 
     >>> from pprint import pprint
     >>> from ansys.grantami.bomanalytics import Connection, queries
-    >>> cxn = Connection(servicelayer_url='http://localhost/mi_servicelayer').with_autologon().connect()
+    >>> cxn = Connection(servicelayer_url='http://my_grantami_server/mi_servicelayer').with_autologon().connect()
     >>> query = (
     ...     queries.MaterialImpactedSubstancesQuery()
     ...     .with_material_ids(['plastic-abs-pvc-flame'])

--- a/README.rst
+++ b/README.rst
@@ -114,7 +114,7 @@ Resources and Links
 For more details, see:
 
   - `PyMAPDL Documentation <https://mapdldocs.pyansys.com/>`_
-  - `PyMAPDL PyPi <https://pypi.org/project/ansys-mapdl-core/>`_
+  - `PyMAPDL PyPI <https://pypi.org/project/ansys-mapdl-core/>`_
   - `PyMAPDL GitHub <https://github.com/pyansys/pymapdl/>`_
 
 
@@ -201,7 +201,7 @@ Resources and Links
 For more details, see:
 
   - `PyAEDT Documentation <https://aedtdocs.pyansys.com/>`_
-  - `PyAEDT PyPi <https://pypi.org/project/pyaedt/>`_
+  - `PyAEDT PyPI <https://pypi.org/project/pyaedt/>`_
   - `PyAEDT GitHub <https://github.com/pyansys/PyAEDT/>`_
 
 
@@ -274,7 +274,7 @@ Resources and Links
 For more details, see:
 
   - `DPF-Core Documentation <https://dpfdocs.pyansys.com/>`__
-  - `DPF-Core PyPi <https://pypi.org/project/ansys-dpf-core/>`__
+  - `DPF-Core PyPI <https://pypi.org/project/ansys-dpf-core/>`__
   - `DPF-Core GitHub <https://github.com/pyansys/DPF-Core>`__
 
 
@@ -344,7 +344,7 @@ Resources and Links
 For more details, see:
 
   - `DPF-Post Documentation <https://dpfdocs.pyansys.com/>`_
-  - `DPF-Post PyPi <https://pypi.org/project/ansys-dpf-core/>`_
+  - `DPF-Post PyPI <https://pypi.org/project/ansys-dpf-core/>`_
   - `DPF-Post GitHub <https://github.com/pyansys/DPF-Post>`_
 
 
@@ -541,7 +541,7 @@ Resources and Links
 For more details, see:
 
   - `Legacy PyMAPDL Reader Documentation <https://readerdocs.pyansys.com/>`_
-  - `Legacy PyMAPDL Reader PyPi <https://pypi.org/project/ansys-mapdl-reader/>`_
+  - `Legacy PyMAPDL Reader PyPI <https://pypi.org/project/ansys-mapdl-reader/>`_
   - `Legacy PyMAPDL Reader GitHub <https://github.com/pyansys/pymapdl-reader>`_
 
 
@@ -591,7 +591,7 @@ Resources and Links
 For more details, see:
 
   - `Granta MI BoM Analytics Documentation <https://grantami.docs.pyansys.com/>`_
-  - `Granta MI BoM Analytics PyPi <https://pypi.org/project/ansys-grantami-bomanalytics/>`_
+  - `Granta MI BoM Analytics PyPI <https://pypi.org/project/ansys-grantami-bomanalytics/>`_
   - `Granta MI BoM Analytics GitHub <https://github.com/pyansys/grantami-bomanalytics/>`_
 
 

--- a/README.rst
+++ b/README.rst
@@ -548,7 +548,7 @@ For more details, see:
 Granta MI BoM Analytics
 -----------------------
 The Granta MI Restricted Substances solution includes BoM Analytic Services,
-which providdes a REST API to allow external applications and tools to determine
+which provides a REST API to allow external applications and tools to determine
 the compliance of materials and products against various legislations. This
 package provides a Pythonic interface to the BoM Analytic Services API.
 

--- a/README.rst
+++ b/README.rst
@@ -13,6 +13,7 @@ has been expanded to five main packages:
 - `PyDPF-Core <https://dpfdocs.pyansys.com/>`__ : Post-Processing using the Data Processing Framework (DPF).  More complex yet and more powerful post-processing APIs.
 - `PyDPF-Post <https://postdocs.pyansys.com/>`__ : Streamlined and simplified DPF Post Processing.  Higher level package and uses ``ansys-dpf-core``.
 - `Legacy PyMAPDL Reader <https://readerdocs.pyansys.com/>`__: Legacy result file reader.  Supports result files from MAPDL v14.5 to the current release.
+- `Granta MI BoM Analytics <https://grantami.docs.pyansys.com/>`__: Pythonic interface to Granta MI BoM Analytic Services.
 
 This is an expanding and developing project.  Feel free to post issues
 on the various GitHub pages in this document.  For additional support,
@@ -542,6 +543,56 @@ For more details, see:
   - `Legacy PyMAPDL Reader Documentation <https://readerdocs.pyansys.com/>`_
   - `Legacy PyMAPDL Reader PyPi <https://pypi.org/project/ansys-mapdl-reader/>`_
   - `Legacy PyMAPDL Reader GitHub <https://github.com/pyansys/pymapdl-reader>`_
+
+
+Granta MI BoM Analytics
+----------------------
+The Granta MI Restricted Substances solution includes BoM Analytic Services, 
+which providdes a REST API to allow external applications and tools to determine
+ the compliance of materials and products against various legislations. This
+package provides a Pythonic interface to the BoM Analytic Services API.
+
+Installation
+~~~~~~~~~~~~
+Install this package with:
+
+.. code::
+
+   pip install ansys-grantami-bomanalytics
+
+Usage
+~~~~~
+Here's a brief example of how this package works:
+
+.. code:: python
+
+    # Connect and query the Granta service.
+
+    >>> from pprint import pprint
+    >>> from ansys.grantami.bomanalytics import Connection, queries
+    >>> cxn = Connection(servicelayer_url='http://localhost/mi_servicelayer').with_autologon().connect()
+    >>> query = (
+    ...     queries.MaterialImpactedSubstancesQuery()
+    ...     .with_material_ids(['plastic-abs-pvc-flame'])
+    ...     .with_legislations(['REACH - The Candidate List'])
+    ... )
+
+    # Print out the result from the query.
+
+    >>> result = cxn.run(query)
+    >>> pprint(result.impacted_substances)
+    [<ImpactedSubstance: {"cas_number": 10108-64-2, "percent_amount": 1.9}>,
+     <ImpactedSubstance: {"cas_number": 107-06-2, "percent_amount": None}>,
+     <ImpactedSubstance: {"cas_number": 115-96-8, "percent_amount": 15.0}>,
+    ...
+
+Resources and Links
+~~~~~~~~~~~~~~~~~~~
+For more details, see:
+
+  - `Granta MI BoM Analytics Documentation <https://grantami.docs.pyansys.com/>`_
+  - `Granta MI BoM Analytics PyPi <https://pypi.org/project/ansys-grantami-bomanalytics/>`_
+  - `Granta MI BoM Analytics GitHub <https://github.com/pyansys/grantami-bomanalytics/>`_
 
 
 License and Acknowledgments

--- a/README.rst
+++ b/README.rst
@@ -546,7 +546,7 @@ For more details, see:
 
 
 Granta MI BoM Analytics
-----------------------
+-----------------------
 The Granta MI Restricted Substances solution includes BoM Analytic Services, 
 which providdes a REST API to allow external applications and tools to determine
  the compliance of materials and products against various legislations. This

--- a/README.rst
+++ b/README.rst
@@ -547,9 +547,9 @@ For more details, see:
 
 Granta MI BoM Analytics
 -----------------------
-The Granta MI Restricted Substances solution includes BoM Analytic Services, 
+The Granta MI Restricted Substances solution includes BoM Analytic Services,
 which providdes a REST API to allow external applications and tools to determine
- the compliance of materials and products against various legislations. This
+the compliance of materials and products against various legislations. This
 package provides a Pythonic interface to the BoM Analytic Services API.
 
 Installation

--- a/README.rst
+++ b/README.rst
@@ -547,10 +547,10 @@ For more details, see:
 
 Granta MI BoM Analytics
 -----------------------
-The Granta MI Restricted Substances solution includes BoM Analytic Services,
+The Granta MI Restricted Substances solution includes BoM Analytics Services,
 which provides a REST API to allow external applications and tools to determine
 the compliance of materials and products against various legislations. This
-package provides a Pythonic interface to the BoM Analytic Services API.
+package provides a Pythonic interface to the BoM Analytics Services API.
 
 Installation
 ~~~~~~~~~~~~

--- a/README.rst
+++ b/README.rst
@@ -13,7 +13,7 @@ has been expanded to five main packages:
 - `PyDPF-Core <https://dpfdocs.pyansys.com/>`__ : Post-Processing using the Data Processing Framework (DPF).  More complex yet and more powerful post-processing APIs.
 - `PyDPF-Post <https://postdocs.pyansys.com/>`__ : Streamlined and simplified DPF Post Processing.  Higher level package and uses ``ansys-dpf-core``.
 - `Legacy PyMAPDL Reader <https://readerdocs.pyansys.com/>`__: Legacy result file reader.  Supports result files from MAPDL v14.5 to the current release.
-- `Granta MI BoM Analytics <https://grantami.docs.pyansys.com/>`__: Pythonic interface to Granta MI BoM Analytic Services.
+- `Granta MI BoM Analytics <https://grantami.docs.pyansys.com/>`__: Pythonic interface to Granta MI BoM Analytics Services.
 
 This is an expanding and developing project.  Feel free to post issues
 on the various GitHub pages in this document.  For additional support,

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -7,7 +7,7 @@
    DPF-Core <https://dpfdocs.pyansys.com/>
    DPF-Post <https://postdocs.pyansys.com/>
    Legacy PyMAPDL Reader <https://readerdocs.pyansys.com/>
-
+   Granta MI BoM Analytics <https://grantami.docs.pyansys.com/>
 
 ..
    Simply reuse the README.rst to avoid duplication


### PR DESCRIPTION
This PR adds the new Granta MI BoM Analytics package to the PyAnsys landing page.

In future the `grantami.docs.pyansys.com` page will transition into a landing page that groups together all Granta MI PyAnsys packages. However, at the moment we only have one, and so we link to it directly.

Before this is merged, it will require a review from someone in the Granta organization.