### PR TITLE
Minor Text Fix

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -547,7 +547,7 @@ For more details, see:
 Shared Components
 -----------------
 The PyAnsys project publishes and consumes shared software components. These enable
-interoperability between PyAnsys packages and minimizes maintenance burden.
+interoperability between PyAnsys packages and minimize maintenance burden.
 
 For more details and a list of the available shared components see the
 `Shared Components Documentation <https://shared.docs.pyansys.com>`_.


### PR DESCRIPTION
Remove a rogue `s` in the text referring to the Shared Components